### PR TITLE
[PL-1764]: Adding fetch tags even when fetch depth is greater than 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ When Git 2.18 or higher is not in your PATH, falls back to the REST API to downl
     # Number of commits to fetch. 0 indicates all history for all branches and tags.
     # Default: 1
     fetch-depth: ''
-
+    
+    # Whether to fetch tags, even if fetch-depth > 0.
+    # Default: false
+    fetch-tags: ''
+    
     # Whether to download Git-LFS files
     # Default: false
     lfs: ''

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -801,6 +801,7 @@ async function setup(testName: string): Promise<void> {
     clean: true,
     commit: '',
     fetchDepth: 1,
+    fetchTags: false,
     lfs: false,
     submodules: false,
     nestedSubmodules: false,

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -80,6 +80,7 @@ describe('input-helper tests', () => {
     expect(settings.commit).toBeTruthy()
     expect(settings.commit).toBe('1234567890123456789012345678901234567890')
     expect(settings.fetchDepth).toBe(1)
+    expect(settings.fetchTags).toBe(false)
     expect(settings.lfs).toBe(false)
     expect(settings.ref).toBe('refs/heads/some-ref')
     expect(settings.repositoryName).toBe('some-repo')

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,9 @@ inputs:
   fetch-depth:
     description: 'Number of commits to fetch. 0 indicates all history for all branches and tags.'
     default: 1
+  fetch-tags:
+    description: 'Whether to fetch tags, even if fetch-depth > 0.'
+    default: false
   lfs:
     description: 'Whether to download Git-LFS files'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -615,10 +615,10 @@ class GitCommandManager {
             return output.exitCode === 0;
         });
     }
-    fetch(refSpec, fetchDepth) {
+    fetch(refSpec, fetchDepth, fetchTags) {
         return __awaiter(this, void 0, void 0, function* () {
             const args = ['-c', 'protocol.version=2', 'fetch'];
-            if (!refSpec.some(x => x === refHelper.tagsRefSpec)) {
+            if (!refSpec.some(x => x === refHelper.tagsRefSpec) && !fetchTags) {
                 args.push('--no-tags');
             }
             args.push('--prune', '--progress', '--no-recurse-submodules');
@@ -1223,7 +1223,7 @@ function getSource(settings) {
             }
             else {
                 const refSpec = refHelper.getRefSpec(settings.ref, settings.commit);
-                yield git.fetch(refSpec, settings.fetchDepth);
+                yield git.fetch(refSpec, settings.fetchDepth, settings.fetchTags);
             }
             core.endGroup();
             // Checkout info
@@ -1679,6 +1679,10 @@ function getInputs() {
             result.fetchDepth = 0;
         }
         core.debug(`fetch depth = ${result.fetchDepth}`);
+        // Fetch tags
+        result.fetchTags =
+        (core.getInput('fetch-tags') || 'false').toUpperCase() === 'TRUE';
+        core.debug(`fetch tags = ${result.fetchTags}`);
         // LFS
         result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE';
         core.debug(`lfs = ${result.lfs}`);

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -25,7 +25,7 @@ export interface IGitCommandManager {
     add?: boolean
   ): Promise<void>
   configExists(configKey: string, globalConfig?: boolean): Promise<boolean>
-  fetch(refSpec: string[], fetchDepth?: number): Promise<void>
+  fetch(refSpec: string[], fetchDepth?: number, fetchTags?: boolean): Promise<void>
   getDefaultBranch(repositoryUrl: string): Promise<string>
   getWorkingDirectory(): string
   init(): Promise<void>
@@ -202,9 +202,9 @@ class GitCommandManager {
     return output.exitCode === 0
   }
 
-  async fetch(refSpec: string[], fetchDepth?: number): Promise<void> {
+  async fetch(refSpec: string[], fetchDepth?: number, fetchTags?: boolean): Promise<void> {
     const args = ['-c', 'protocol.version=2', 'fetch']
-    if (!refSpec.some(x => x === refHelper.tagsRefSpec)) {
+    if (!refSpec.some(x => x === refHelper.tagsRefSpec) && !fetchTags) {
       args.push('--no-tags')
     }
 

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -169,7 +169,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       }
     } else {
       const refSpec = refHelper.getRefSpec(settings.ref, settings.commit)
-      await git.fetch(refSpec, settings.fetchDepth)
+      await git.fetch(refSpec, settings.fetchDepth, settings.fetchTags)
     }
     core.endGroup()
 

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -35,6 +35,11 @@ export interface IGitSourceSettings {
   fetchDepth: number
 
   /**
+   * Fetch tags, even if fetchDepth > 0 (default: false)
+   */
+  fetchTags: boolean
+
+  /**
    * Indicates whether to fetch LFS objects
    */
   lfs: boolean

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -89,6 +89,11 @@ export async function getInputs(): Promise<IGitSourceSettings> {
   }
   core.debug(`fetch depth = ${result.fetchDepth}`)
 
+  // Fetch tags
+  result.fetchTags =
+    (core.getInput('fetch-tags') || 'false').toUpperCase() === 'TRUE'
+  core.debug(`fetch tags = ${result.fetchTags}`)
+
   // LFS
   result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE'
   core.debug(`lfs = ${result.lfs}`)


### PR DESCRIPTION
Comparing the 2 builds, after adding these changes to self-service, the download for the repo is less: 

Fetch Depth as 50 and Fetch Tags present comes to about 800 MB
https://github.com/qmetric/self-service/actions/runs/4795251874/jobs/8529578918

Normal actions/checkout: (This comes to about 3GB)
https://github.com/qmetric/self-service/actions/runs/4788775710/jobs/8515829340 